### PR TITLE
Multiboot2 compliance fixes

### DIFF
--- a/loader/src/init32.S
+++ b/loader/src/init32.S
@@ -25,7 +25,7 @@ multiboot2Header:
 
 	.short MULTIBOOT_HEADER_TAG_END
 	.short 0
-	.int 0
+	.int 8
 multiboot2HeaderEnd:
 
 .section .initCode, "ax"


### PR DESCRIPTION
Multiboot2 specifications state that the end tag has a size of 8, not 0. This fixes `init32.S`